### PR TITLE
fix: stat searching when page is loaded

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -17,6 +17,7 @@
       "matches": [
         "https://*/*"
       ],
+      "run_at": "document_end",
       "js": [
         "dist/content_script.js"
       ]

--- a/src/background_script.js
+++ b/src/background_script.js
@@ -1,31 +1,21 @@
 const metaAssets = '../meta_assets/';
 var selectedId = -1;
 
-function getIconPath(response) {
-	const suffix = response.length ? '' : '_without';
-	return `${metaAssets}icon${suffix}.png`;
+function getIconPath(hasCustomElement) {
+  const suffix = hasCustomElement ? '' : '_without';
+  return `${metaAssets}icon${suffix}.png`;
 }
 
-function updateIcon() {
-	chrome.tabs.sendMessage(selectedId, {msg: "findAll"}, (response = []) => {
-		chrome.browserAction.setIcon({
-			path: getIconPath(response),
-			tabId: selectedId
-		});
-	});
+function updateIcon(customElementCount) {
+  chrome.browserAction.setIcon({
+    path: getIconPath(!!customElementCount),
+    tabId: selectedId
+  });
 }
 
-chrome.tabs.onUpdated.addListener(function(tabId, props) {
-  if (props.status == "complete" && tabId == selectedId)
-    updateIcon();
-});
-
-chrome.tabs.onSelectionChanged.addListener(function(tabId, props) {
-  selectedId = tabId;
-  updateIcon();
-});
-
-chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
-  selectedId = tabs[0].id;
-  updateIcon();
+chrome.runtime.onMessage.addListener(function(request, sender) {
+  if (request.msg == "customElementCount") {
+    selectedId = sender.tab.id;
+    updateIcon(request.value);
+  }
 });

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -30,12 +30,6 @@ chrome.runtime.onConnect.addListener(function(port) {
 
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 
-  if(request.msg === "findAll") {
-    allCustomElements = [];
-    findAllCustomElements(document.querySelectorAll('*'));
-    sendResponse(allCustomElements)
-  }
-
   if(request.msg === "init") {
     // Custom elements are already found.
     // Return cached ones.
@@ -96,3 +90,18 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     lastElement = request.elementName;
   }
 });
+
+function notifyCustomElementCount() {
+	chrome.runtime.sendMessage({
+    msg: "customElementCount",
+    value: allCustomElements.length
+  });
+}
+
+function initSearch() {
+  findAllCustomElements(document.querySelectorAll('*'));
+  notifyCustomElementCount();
+}
+
+// Wait to the whole page is loaded.
+window.addEventListener('load', initSearch);


### PR DESCRIPTION
Run content script at "document_end": https://developer.chrome.com/extensions/content_scripts#run_time

Call `initSearch` on `document.load` and notify the background the results to decide which icon set.